### PR TITLE
feat: add devShell re-exporting from flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,3 +124,38 @@ jobs:
             pwd
             cowsay hello
             command -v docker
+
+  test-flakes-from-devshell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Test Bash Shell with Local and External Flakes
+        uses: ./
+        with:
+          flakes-from-devshell: true
+          script: |
+            pwd
+            figlet "I'm from the devshell, baby."
+
+  test-flakes-from-devshell-in-working-directory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Test Bash Shell with Local and External Flakes
+        uses: ./
+        with:
+          working-directory: test/working-directory
+          flakes-from-devshell: true
+          script: |
+            pwd
+            cmatrix

--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ jobs:
             command -v docker
 ```
 
+### Flakes from devShell
+Instead of specifying `flakes`, you can also tell this action to re-use the `buildInputs` from your `devShell` defined in a `flake.nix`, and automatically make these available to the script:
+
+```yaml
+name: "Test with Flakes from DevShell"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: workflow/nix-shell-action@v3
+        with:
+          flakes-from-devshell: true
+          script: |
+            # Runs hello from a local flake.nix with a `devShell`
+            hello
+```
+
 ## Options `with: ...`
 
 - `interpreter`:  Interpreter to use in the nix shell shebang, defaults to `bash`. (This is passed to `nix run -c`, used to be `-i` in a nix shell shebang)
@@ -82,6 +108,8 @@ jobs:
 - `packages`: Comma-separated list of packages to pre-install in your shell. Defaults to just `bash`. Cannot be used together with the `flakes` option.
 
 - `flakes`: Comma-separated list of fully qualified flakes to pre-install in your shell. Use either `packages` or `flakes`. Cannot be used together with the `packages` option.
+
+- `flakes-from-devshell`: If true, supply flakes from a `devShell` provided in your repo's `flake.nix`. You cannot currently combined this with the `flakes` option.
 
 - `script`: The actual script to execute in your shell. Will be passed to the `interpreter`, which defaults to `bash`
 
@@ -119,4 +147,4 @@ jobs:
 See https://github.com/actions/typescript-action
 
 [Nix]: https://nixos.org/nix/
-[install-nix-action]: https://github.com/marketplace/actions/install-nix 
+[install-nix-action]: https://github.com/marketplace/actions/install-nix

--- a/flake.nix
+++ b/flake.nix
@@ -7,5 +7,9 @@
 
     packages.x86_64-linux.default = self.packages.x86_64-linux.hello;
 
+    packages.x86_64-linux.devShell = nixpkgs.legacyPackages.x86_64-linux.mkShell {
+      buildInputs = [ self.packages.x86_64-linux.figlet ];
+    };
+
   };
 }

--- a/test/devshell-flake/flake.lock
+++ b/test/devshell-flake/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/test/devshell-flake/flake.nix
+++ b/test/devshell-flake/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "A basic flake with a special devShell package";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { ... }@inputs: inputs.flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import inputs.nixpkgs { inherit system; };
+    in
+    {
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          cmatrix
+        ];
+      };
+    });
+}
+


### PR DESCRIPTION
Would be nice to have an option to automatically make packages defined as a `devShell` `buildInput` in flake.nix available in the environment.

See https://github.com/workflow/nix-shell-action/issues/196#issuecomment-1402631754